### PR TITLE
feat(projects): add "Open in New Window" button for HTML / HTML-PPT f…

### DIFF
--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -5,6 +5,7 @@ import {
   ChevronLeft,
   ChevronRight,
   Edit,
+  ExternalLink,
   Folder,
   FolderOpen,
   MoreVertical,
@@ -34,6 +35,10 @@ import {formatDate} from '@/lib/utils'
 import type {Group, Project} from '@/types'
 import {ProjectRepository} from '@/services/projectRepository'
 import {GroupRepository} from '@/services/groupRepository'
+import {VersionRepository} from '@/services/versionRepository'
+import {buildHtmlSrcDoc} from '@/lib/htmlShells'
+import {buildPptSrcDoc} from '@/lib/htmlPpt/srcdocBuilder'
+import {sanitizeHtml} from '@/lib/validators/html'
 import {useSystemStore} from '@/stores/systemStore'
 
 export function ProjectsPage() {
@@ -171,6 +176,25 @@ export function ProjectsPage() {
   const openRenameDialog = (project: Project) => {
     setRenameTarget(project)
     setNewTitle(project.title)
+  }
+
+  const handleOpenInNewWindow = async (project: Project) => {
+    try {
+      const latest = await VersionRepository.getLatest(project.id)
+      const rawHtml = latest?.content ?? ''
+      const sanitized = sanitizeHtml(rawHtml)
+      const themeId = project.styleVariant ?? ''
+      const srcDoc = project.engineType === 'html-ppt'
+        ? buildPptSrcDoc({ themeId, body: sanitized, title: project.title, activeIndex: 0, includeNavScript: true })
+        : buildHtmlSrcDoc(themeId, sanitized, project.title)
+      const blob = new Blob([srcDoc], { type: 'text/html;charset=utf-8' })
+      const href = URL.createObjectURL(blob)
+      const win = window.open(href, '_blank')
+      if (!win) console.warn('[ProjectsPage] Popup blocked; preview URL:', href)
+      setTimeout(() => URL.revokeObjectURL(href), 60_000)
+    } catch (error) {
+      console.error('Failed to open project in new window:', error)
+    }
   }
 
   // --- Group Actions ---
@@ -830,16 +854,28 @@ export function ProjectsPage() {
                     <span>{i18nTexts.projectsUpdateTime[language]}：{previewProject && formatDate(previewProject.updatedAt, true)}</span>
                   </div>
                 </div>
-                <Button
-                  onClick={() => {
-                    if (previewProject) {
-                      navigate(`/editor/${previewProject.id}`)
-                    }
-                  }}
-                  className="rounded-full px-8 h-12 text-base shrink-0"
-                >
-                  {i18nTexts.projectsEnterEdit[language]}
-                </Button>
+                <div className="flex items-center gap-2 shrink-0">
+                  {previewProject && (previewProject.engineType === 'html' || previewProject.engineType === 'html-ppt') && (
+                    <Button
+                      variant="outline"
+                      onClick={() => handleOpenInNewWindow(previewProject)}
+                      className="rounded-full px-6 h-12 text-base gap-2"
+                    >
+                      <ExternalLink className="h-4 w-4" />
+                      {i18nTexts.projectsOpenInNewWindow[language]}
+                    </Button>
+                  )}
+                  <Button
+                    onClick={() => {
+                      if (previewProject) {
+                        navigate(`/editor/${previewProject.id}`)
+                      }
+                    }}
+                    className="rounded-full px-8 h-12 text-base"
+                  >
+                    {i18nTexts.projectsEnterEdit[language]}
+                  </Button>
+                </div>
               </div>
             </div>
           </div>

--- a/src/stores/systemStore.ts
+++ b/src/stores/systemStore.ts
@@ -143,6 +143,7 @@ export interface I18nTexts {
   projectsUpdatedAt: { zh: string; en: string }
   projectsPreviewTitle: { zh: string; en: string }
   projectsEnterEdit: { zh: string; en: string }
+  projectsOpenInNewWindow: { zh: string; en: string }
   projectsNoPreview: { zh: string; en: string }
   projectsCreateTime: { zh: string; en: string }
   projectsUpdateTime: { zh: string; en: string }
@@ -441,6 +442,7 @@ export const useSystemStore = create<SystemState>((set) => ({
     projectsUpdatedAt: { zh: '更新于', en: 'Updated' },
     projectsPreviewTitle: { zh: '暂无预览图', en: 'No Preview' },
     projectsEnterEdit: { zh: '进入编辑', en: 'Enter Edit' },
+    projectsOpenInNewWindow: { zh: '新窗口打开', en: 'Open in New Window' },
     projectsNoPreview: { zh: '暂无预览图', en: 'No Preview' },
     projectsCreateTime: { zh: '创建时间', en: 'Created Time' },
     projectsUpdateTime: { zh: '更新时间', en: 'Updated Time' },


### PR DESCRIPTION
…iles

In the file preview dialog, HTML and HTML-PPT files now show an extra "新窗口打开" button next to "进入编辑". It loads the project's latest version, builds the same standalone srcdoc used by the editor's renderers, and opens the result in a new tab so users can preview a deck or diagram without entering the editor.

Refs: MY-6